### PR TITLE
LiteDB 5.0.12 -> 5.0.16

### DIFF
--- a/VoiceOfClock.Core/VoiceOfClock.Core.csproj
+++ b/VoiceOfClock.Core/VoiceOfClock.Core.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Diagnostics" Version="8.0.0" />
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
-    <PackageReference Include="LiteDB" Version="5.0.12" />
+    <PackageReference Include="LiteDB" Version="5.0.16" />
   </ItemGroup>
 
 </Project>

--- a/VoiceOfClock/VoiceOfClock.csproj
+++ b/VoiceOfClock/VoiceOfClock.csproj
@@ -59,7 +59,7 @@
     </PackageReference>
     <PackageReference Include="DryIoc.dll" Version="5.2.2" />
     <PackageReference Include="I18NPortable" Version="1.0.1" />
-    <PackageReference Include="LiteDB" Version="5.0.12" />
+    <PackageReference Include="LiteDB" Version="5.0.16" />
     <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="ReactiveProperty" Version="8.1.2" />


### PR DESCRIPTION
JSONシリアライザの脆弱性対応のため。

x64 リリースビルドで実行して起動問題無し。